### PR TITLE
PUBG API 22.0.1: Add ban type to player object

### DIFF
--- a/src/main/java/com/github/gplnature/pubgapi/model/player/PlayerAttributes.java
+++ b/src/main/java/com/github/gplnature/pubgapi/model/player/PlayerAttributes.java
@@ -13,6 +13,8 @@ public class PlayerAttributes {
 
     private String shardId;
 
+    private String banType;
+
     private String titleId;
 
     public PlayerAttributes() {
@@ -53,5 +55,13 @@ public class PlayerAttributes {
 
     public void setTitleId(String titleId) {
         this.titleId = titleId;
+    }
+
+    public String getBanType() {
+        return banType;
+    }
+
+    public void setBanType(String banType) {
+        this.banType = banType;
     }
 }


### PR DESCRIPTION
Hi,
i added this:  Add ban type to player object

https://documentation.pubg.com/en/changelog/changelog.html#v22-0-1