### PR TITLE
Introduce UNKNOWN Map to ensure new maps do not crash the match api in the future

### DIFF
--- a/src/main/java/com/github/gplnature/pubgapi/api/AbstractPubgClient.java
+++ b/src/main/java/com/github/gplnature/pubgapi/api/AbstractPubgClient.java
@@ -183,6 +183,7 @@ public abstract class AbstractPubgClient {
         mapper.registerModule(module);
 
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true);
 
         // Build the interface to the API
         Retrofit retrofit = new Retrofit.Builder()

--- a/src/main/java/com/github/gplnature/pubgapi/model/Map.java
+++ b/src/main/java/com/github/gplnature/pubgapi/model/Map.java
@@ -1,6 +1,7 @@
 package com.github.gplnature.pubgapi.model;
 
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum Map {
@@ -15,4 +16,5 @@ public enum Map {
     @JsonProperty("Heaven_Main") HEAVEN_MAIN,
     @JsonProperty("Tiger_Main") TAEGO_MAIN,
     @JsonProperty("Tutorial_Main") TUTORIAL_MAIN,
+    @JsonEnumDefaultValue @JsonProperty("Unknown") UNKNOWN,
 }


### PR DESCRIPTION
- Added a default map called Unknown
- Enabled 'Read unknown enums as default value' to prevent crashes if new maps are added

This would change the behavior to returning the default enum value marked with @JsonEnumDefaultValue instead of crashing on an unknown enum value.

Pro:
- Now could retrieve match statistics on future maps even when api is not yet updated

Con:
- Could potentially lead to unwanted behavior in other enum classes and/or user tools that expect the InvalidFormatException 
  - (I can't think of any reason where this may be the case though but still wanted to hint at it)